### PR TITLE
[Algorithm] Added option to round runtimes to minutes on stops (not gas switches)

### DIFF
--- a/projects/scuba-physics/src/lib/algorithm/BuhlmannAlgorithm.spec.ts
+++ b/projects/scuba-physics/src/lib/algorithm/BuhlmannAlgorithm.spec.ts
@@ -38,6 +38,7 @@ describe('Buhlmann Algorithm - Plan', () => {
         options.safetyStop = SafetyStop.always;
         options.salinity = Salinity.salt;
         options.roundStopsToMinutes = true;
+        options.roundRuntimesToMinutes = false;
         options.decoStopDistance = 3;
         options.altitude = 0;
     });
@@ -249,6 +250,25 @@ describe('Buhlmann Algorithm - Plan', () => {
 
         const expectedPlan = '0,40,120; 40,40,1680; 40,21,114; 21,21,60; 21,15,36; 15,15,60; 15,12,18; ' +
             '12,12,120; 12,9,18; 9,9,180; 9,6,18; 6,6,360; 6,3,18; 3,3,900; 3,0,18;';
+        expect(planText).toBe(expectedPlan);
+    });
+
+    it('40m for 30 minutes using air, ean50, oxygen rounding for runtime', () => {
+        const gases = new Gases();
+        gases.add(StandardGases.air);
+        gases.add(StandardGases.ean50);
+        gases.add(StandardGases.oxygen);
+
+        const segments = new Segments();
+        segments.add(40, StandardGases.air, 2 * Time.oneMinute);
+        segments.addFlat(StandardGases.air, 28 * Time.oneMinute);
+        options.roundRuntimesToMinutes = true;
+        options.roundStopsToMinutes = false;
+        const planText = calculatePlan(gases, segments);
+
+        // gas switch at 21 meters is not rounded in runtime
+        const expectedPlan = '0,40,120; 40,40,1680; 40,21,114; 21,21,60; 21,15,36; 15,15,30; 15,12,18; ' +
+            '12,12,162; 12,9,18; 9,9,222; 9,6,18; 6,6,222; 6,3,18; 3,3,582; 3,0,18;';
         expect(planText).toBe(expectedPlan);
     });
 

--- a/projects/scuba-physics/src/lib/algorithm/BuhlmannAlgorithm.ts
+++ b/projects/scuba-physics/src/lib/algorithm/BuhlmannAlgorithm.ts
@@ -232,7 +232,14 @@ export class BuhlmannAlgorithm {
             // the algorithm returns lowest value, so the last second where the deco isn't enough
             // so we need to add one more second to be safe and adjust it to the required rounding
             const stopDuration = interval.search(searchContext) + Time.oneSecond;
-            const rounded = Precision.ceilDistance(stopDuration, context.decoStopDuration);
+            let rounded = Precision.ceilDistance(stopDuration, context.decoStopDuration);
+            if (context.options.roundRuntimesToMinutes){
+                context.restore(memento);
+                const secondsDeco = (context.runTime + rounded) % 60;
+                if (secondsDeco !== 0){
+                    rounded += 60 - secondsDeco;
+                }
+            }
             this.swimDecoStop(context, memento, rounded);
         }
     }

--- a/projects/scuba-physics/src/lib/algorithm/Options.ts
+++ b/projects/scuba-physics/src/lib/algorithm/Options.ts
@@ -16,6 +16,7 @@ export class OptionDefaults {
     public static readonly altitude = 0;
     public static readonly saltWater = Salinity.salt;
     public static readonly roundStopsToMinutes = false;
+    public static readonly roundRuntimesToMinutes = false;
     public static readonly gasSwitchDuration = 2;
     public static readonly problemSolvingDuration = 1;
     public static readonly lastStopDepth = 3;
@@ -89,6 +90,10 @@ export class Options implements GasOptions, DepthOptions, DepthLevelOptions, Spe
     /** If true (default) deco stops are rounded up to whole minutes (I.e. longer ascent).
      *  Otherwise, length of stops is not rounded and profile generates precise stops in seconds .  */
     public roundStopsToMinutes = OptionDefaults.roundStopsToMinutes;
+
+    /** If true deco stops are rounded up to whole minutes for runtime (I.e. longer ascent).
+     *  Otherwise (default), length of stops is not rounded and profile generates precise stops in seconds .  */
+    public roundRuntimesToMinutes = OptionDefaults.roundRuntimesToMinutes;
 
     /** Gas switch stop length in minutes */
     public gasSwitchDuration = OptionDefaults.gasSwitchDuration;


### PR DESCRIPTION
## Summary
Keeping runtimes in minutes is more useful than keeping stops to minutes, so this adds an option to do just that. Undefined behavior will occur if `options.roundRuntimesToMinutes && options.roundStopsToMinutes` (it will just round up to the minute first, then add more time, potentially causing an unnecessarily long stop). 

## Test Plan
Added unit test

